### PR TITLE
ブログ投稿詳細画面の表示

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -12,5 +12,10 @@ class PostController extends Controller
         return view('posts.index')->with(['posts' => $post->getPaginateByLimit(1)]);  
        //blade内で使う変数'posts'と設定。'posts'の中身にgetを使い、インスタンス化した$postを代入。
     }
+    
+    public function show(Post $post)
+    {
+        return view('posts.show')->with(['post' => $post]);
+ //'post'はbladeファイルで使う変数。中身は$postはid=1のPostインスタンス。
+    }
 }
-?>

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -11,7 +11,9 @@
         <div class='posts'>
             @foreach ($posts as $post)
                 <div class='post'>
-                    <h2 class='title'>{{ $post->title }}</h2>
+                    <h2 class='title'>
+                        <a href="/posts/{{ $post->id }}">{{ $post->title }}</a>
+                    </h2>
                     <p class='body'>{{ $post->body }}</p>
                 </div>
             @endforeach

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -1,0 +1,24 @@
+<!DOCTYPE HTML>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Posts</title>
+        <!-- Fonts -->
+        <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
+    </head>
+    <body>
+        <h1 class="title">
+            {{ $post->title }}
+        </h1>
+        <div class="content">
+            <div class="content__post">
+                <h3>本文</h3>
+                <p>{{ $post->body }}</p>    
+            </div>
+        </div>
+        <div class="footer">
+            <a href="/">戻る</a>
+        </div>
+    </body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,3 +21,5 @@ Route::get('/', function () {
 Route::get('/posts', [PostController::class, 'index']);
 
 Route::get('/', [PostController::class, 'index']);
+
+Route::get('/posts/{post}', [PostController::class ,'show']);


### PR DESCRIPTION
投稿タイトルをリンクに変更し、押下すると対象のブログ投稿の詳細画面に移動するようにした。
